### PR TITLE
Improve pagination markup to honor 5.7 onEachSide()

### DIFF
--- a/src/PaginateRoute.php
+++ b/src/PaginateRoute.php
@@ -184,9 +184,9 @@ class PaginateRoute
         }
 
         $urls = [];
-
-        for ($page = 1; $page <= $paginator->lastPage(); $page++) {
-            $urls[] = $this->pageUrl($page, $full);
+        $total = $paginator->currentPage() + $paginator->onEachSide;
+        for ($page = $paginator->currentPage(); $page <= $total; $page++) {
+            $urls[$page] = $this->pageUrl($page, $full);
         }
 
         return $urls;
@@ -219,14 +219,16 @@ class PaginateRoute
         }
 
         foreach ($urls as $i => $url) {
-            $pageNum = $i + 1;
+            $pageNum = $i;
             $css = '';
 
+            $link = "<a href=\"{$url}\">{$pageNum}</a>";
             if ($pageNum == $this->currentPage()) {
                 $css = ' class="active"';
+                $link = $pageNum;
             }
 
-            $listItems .= "<li{$css}><a href=\"{$url}\">{$pageNum}</a></li>";
+            $listItems .= "<li{$css}>$link</li>";
         }
 
         if ($this->hasNextPage($paginator) && $additionalLinks) {

--- a/src/PaginateRoute.php
+++ b/src/PaginateRoute.php
@@ -183,34 +183,58 @@ class PaginateRoute
         }
 
         $urls = [];
-        $side = $paginator->onEachSide;
-        $current = $paginator->currentPage();
-        $last = $paginator->lastPage();
-
-        if (!empty($side)) {
-            $total = $current + $side;
-            $first = $current - $side;
-            if ($first < 1) {
-                $first = 1;
-                $total += $side;
-            }
-            if ($total > $last) {
-                $total = $last;
-                if ($first > $side + 1) {
-                    $first -= $side;
-                }
-            }
-        }
-        else {
-            $first = 1;
-            $total = $last;
-        }
-        for ($page = $first; $page <= $total; $page++) {
+        $left = $this->getLeftPoint($paginator);
+        $right = $this->getRightPoint($paginator);
+        for ($page = $left; $page <= $right; $page++) {
             $urls[$page] = $this->pageUrl($page, $full);
         }
 
         return $urls;
     }
+
+
+    /**
+     * Get the left most point in the pagination element
+     * 
+     * @param LengthAwarePaginator $paginator
+     * @return int
+     */
+    public function getLeftPoint(LengthAwarePaginator $paginator)
+    {
+        $side = $paginator->onEachSide;
+        $current = $paginator->currentPage();
+        $last = $paginator->lastPage();
+        
+        if (!empty($side)) {
+            $x = $current + $side;
+            $offset = $x > $last ? $x - $last : 0;
+            $left = $current - $side - $offset;
+        }
+        
+        return !isset($left) || $left < 1 ? 1 : $left;
+    }
+
+
+    /**
+     * Get the right or last point of the pagination element
+     * 
+     * @param LengthAwarePaginator $paginator
+     * @return int
+     */
+    public function getRightPoint(LengthAwarePaginator $paginator)
+    {
+        $side = $paginator->onEachSide;
+        $current = $paginator->currentPage();
+        $last = $paginator->lastPage();
+
+        if (!empty($side)) {
+            $offset = $current < $side ? $side - $current + 1 : 0;
+            $right = $current + $side + $offset;
+        }
+
+        return !isset($right) || $right > $last ? $last : $right;
+    }
+    
 
     /**
      * Render a plain html list with previous, next and all urls. The current page gets a current class on the list item.

--- a/src/PaginateRoute.php
+++ b/src/PaginateRoute.php
@@ -192,7 +192,6 @@ class PaginateRoute
         return $urls;
     }
 
-
     /**
      * Get the left most point in the pagination element
      * 
@@ -207,13 +206,12 @@ class PaginateRoute
         
         if (!empty($side)) {
             $x = $current + $side;
-            $offset = $x > $last ? $x - $last : 0;
+            $offset = $x >= $last ? $x - $last : 0;
             $left = $current - $side - $offset;
         }
         
         return !isset($left) || $left < 1 ? 1 : $left;
     }
-
 
     /**
      * Get the right or last point of the pagination element
@@ -228,14 +226,13 @@ class PaginateRoute
         $last = $paginator->lastPage();
 
         if (!empty($side)) {
-            $offset = $current < $side ? $side - $current + 1 : 0;
+            $offset = $current <= $side ? $side - $current + 1 : 0;
             $right = $current + $side + $offset;
         }
 
         return !isset($right) || $right > $last ? $last : $right;
     }
     
-
     /**
      * Render a plain html list with previous, next and all urls. The current page gets a current class on the list item.
      *

--- a/src/PaginateRoute.php
+++ b/src/PaginateRoute.php
@@ -167,7 +167,6 @@ class PaginateRoute
 
         return $this->pageUrl($previousPage, $full);
     }
-
     /**
      * Get all urls in an array.
      *
@@ -184,8 +183,22 @@ class PaginateRoute
         }
 
         $urls = [];
-        $total = $paginator->currentPage() + $paginator->onEachSide;
-        for ($page = $paginator->currentPage(); $page <= $total; $page++) {
+        $side = $paginator->onEachSide;
+        $current = $paginator->currentPage();
+
+        if (!empty($side)) {
+            $total = $current + $side;
+            $first = $current - $side;
+            if ($first < 1) {
+                $first = 1;
+                $total += $side;
+            }
+        }
+        else {
+            $first = 1;
+            $total = $paginator->lastPage();
+        }
+        for ($page = $first; $page <= $total; $page++) {
             $urls[$page] = $this->pageUrl($page, $full);
         }
 

--- a/src/PaginateRoute.php
+++ b/src/PaginateRoute.php
@@ -196,6 +196,9 @@ class PaginateRoute
             }
             if ($total > $last) {
                 $total = $last;
+                if ($first > $side + 1) {
+                    $first -= $side;
+                }
             }
         }
         else {

--- a/src/PaginateRoute.php
+++ b/src/PaginateRoute.php
@@ -185,6 +185,7 @@ class PaginateRoute
         $urls = [];
         $side = $paginator->onEachSide;
         $current = $paginator->currentPage();
+        $last = $paginator->lastPage();
 
         if (!empty($side)) {
             $total = $current + $side;
@@ -193,10 +194,13 @@ class PaginateRoute
                 $first = 1;
                 $total += $side;
             }
+            if ($total > $last) {
+                $total = $last;
+            }
         }
         else {
             $first = 1;
-            $total = $paginator->lastPage();
+            $total = $last;
         }
         for ($page = $first; $page <= $total; $page++) {
             $urls[$page] = $this->pageUrl($page, $full);

--- a/tests/PaginateRouteTest.php
+++ b/tests/PaginateRouteTest.php
@@ -152,6 +152,85 @@ class PaginateRouteTest extends TestCase
 
         $this->assertEquals($allUrlsFull, $response['allUrlsFull']);
     }
+    
+    /**
+     * @test
+     */
+    public function it_returns_limited_urls_with_on_each_side()
+    { 
+        $this->app['router']->paginate('dummies', function () {
+            $dummies = Dummy::paginate(5)->onEachSide(5);
+            $paginateRoute = $this->app['paginateroute'];
+
+            return [
+                'allUrls' => $this->app['paginateroute']->allUrls($dummies),
+                'allUrlsFull' => $this->app['paginateroute']->allUrls($dummies, true),
+            ];
+        });
+
+        $response = $this->callRoute('/');
+
+        // 5 items plus 5 on the side and 1 current item = 11 items visible
+        $allUrls = [
+            $this->hostName.'/dummies',
+            $this->hostName.'/dummies/page/2',
+            $this->hostName.'/dummies/page/3',
+            $this->hostName.'/dummies/page/4',
+            $this->hostName.'/dummies/page/5',
+            $this->hostName.'/dummies/page/6',
+            $this->hostName.'/dummies/page/7',
+            $this->hostName.'/dummies/page/8',
+            $this->hostName.'/dummies/page/9',
+            $this->hostName.'/dummies/page/10',
+            $this->hostName.'/dummies/page/11',
+        ];
+
+        $this->assertEquals($allUrls, $response['allUrls']);
+
+        $allUrlsFull = $allUrls;
+        $allUrlsFull[0] = $this->hostName.'/dummies/page/1';
+
+        $this->assertEquals($allUrlsFull, $response['allUrlsFull']);
+    }
+    
+    /**
+     * @test
+     */
+    public function it_return_zero_on_left_and_ten_on_right_with_on_each_side()
+    {
+        $this->registerDefaultRouteWithEachSide();
+
+        $response = $this->callRoute('/page/1');
+        
+        $this->assertEquals($response['leftPoint'], 1);
+        $this->assertEquals($response['rightPoint'], 11);
+    }
+    
+    /**
+     * @test
+     */
+    public function it_return_five_on_left_and_five_on_right_with_on_each_side()
+    {
+        $this->registerDefaultRouteWithEachSide();
+        $response = $this->callRoute('/page/6');
+
+        $this->assertEquals($response['leftPoint'], 1);
+        $this->assertEquals($response['rightPoint'], 11);
+    }
+    
+    /**
+     * @test
+     */
+    public function it_return_ten_on_left_and_zero_on_right_with_on_each_side()
+    {
+        $this->registerDefaultRouteWithEachSide();
+        $dummies = Dummy::paginate(5)->onEachSide(5);
+        $end = $dummies->lastPage();
+        $response = $this->callRoute('/page/' . $end);
+
+        $this->assertEquals($response['leftPoint'], $end - 10);
+        $this->assertEquals($response['rightPoint'], $end);
+    }
 
     /**
      * @test

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -86,6 +86,24 @@ abstract class TestCase extends Orchestra
             ];
         });
     }
+    
+    protected function registerDefaultRouteWithEachSide()
+    {
+        $this->app['router']->paginate('dummies', function () {
+            $dummies = Dummy::paginate(5)->onEachSide(5);
+            $paginateRoute = $this->app['paginateroute'];
+            return [
+                'nextPageUrl' => $this->app['paginateroute']->nextPageUrl($dummies),
+                'hasPrevious' => $this->app['paginateroute']->hasPreviousPage(),
+                'previousPageUrl' => $this->app['paginateroute']->previousPageUrl(),
+                'models' => $dummies->toArray(),
+                'hasNext' => $this->app['paginateroute']->hasNextPage($dummies),
+                'rightPoint' => $paginateRoute->getRightPoint($dummies),
+                'leftPoint' => $paginateRoute->getLeftPoint($dummies),
+            ];
+        });
+    }
+
 
     /**
      * @param string $route


### PR DESCRIPTION
This improvement will limit how many links markup should be displayed instead of just showing every links, which would be problematic if model has many pages.

The limit will honor 5.7 onEachSide() value that user can be set after paginate() method